### PR TITLE
[codex] fix css export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "import": "./dist/vitepress-mermaid-renderer.js",
       "default": "./dist/vitepress-mermaid-renderer.js"
     },
-    "./css": "./dist/vitepress-mermaid-renderer.css"
+    "./css": "./dist/index.css"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Update the CSS subpath export to point at the stylesheet emitted by the release build.

## Root cause

The package exports `./css` as `./dist/vitepress-mermaid-renderer.css`, but the Vite library build emits and packs `dist/index.css`. Importing the documented CSS subpath therefore resolves to a missing file in the published package.

## Changes

- Point `exports["./css"]` to `./dist/index.css`.

## Validation

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run test`
- `npm pack --dry-run --json`